### PR TITLE
fix: export `encodeGenerator`

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -126,7 +126,7 @@ function bpe(token: string, cache: Map<string, string> = new Map()): string {
   return result
 }
 
-function* encodeGenerator(
+export function* encodeGenerator(
   text: string,
   cache: Map<string, string> = new Map(),
 ): Generator<number[], void, undefined> {


### PR DESCRIPTION
`encodeGenerator()` is not being exported