### PR TITLE
Add gpt-4-32k to mappings

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -14,6 +14,7 @@ export const encodingNames = [
 export const modelToEncodingMap = {
   // chat
   'gpt-4': cl100k_base,
+  'gpt-4-32k': cl100k_base,
   'gpt-3.5-turbo': cl100k_base,
   // text
   'text-davinci-003': p50k_base,


### PR DESCRIPTION
Needed for the work on https://github.com/niieani/gpt-tokenizer-demo/pull/3 

I dont have access to 32k but from looking at code examples, this is the name of the 32k GPT4 model