### PR TITLE
feat: add price data to GPT-5 Nano models | Fixes #86

### DIFF
--- a/src/model/gpt-5-nano-2025-08-07.ts
+++ b/src/model/gpt-5-nano-2025-08-07.ts
@@ -9,7 +9,7 @@ import { GptEncoding } from '../GptEncoding.js'
 export * from '../constants.js'
 export * from '../specialTokens.js'
 // prettier-ignore
-const api = GptEncoding.getEncodingApiForModel('gpt-5-nano-2025-08-07', () => bpeRanks, {name:"gpt-5-nano-2025-08-07",slug:"gpt-5-nano-2025-08-07",performance:2,latency:5,modalities:{input:["text","image"],output:["text"]},context_window:400000,max_output_tokens:128000,max_input_tokens:272000,knowledge_cutoff:new Date(1717113600000),supported_features:["streaming","function_calling","file_search","file_uploads","structured_outputs","image_input","prompt_caching"],supported_endpoints:["chat_completions","responses","batch"],reasoning_tokens:true})
+const api = GptEncoding.getEncodingApiForModel('gpt-5-nano-2025-08-07', () => bpeRanks, {name:"gpt-5-nano-2025-08-07",slug:"gpt-5-nano-2025-08-07",performance:2,latency:5,modalities:{input:["text","image"],output:["text"]},context_window:400000,max_output_tokens:128000,max_input_tokens:272000,knowledge_cutoff:new Date(1717113600000),supported_features:["streaming","function_calling","file_search","file_uploads","structured_outputs","image_input","prompt_caching"],supported_endpoints:["chat_completions","responses","batch"],reasoning_tokens:true,price_data:{main:{input:.05,output:.4,cached_input:.005},batch:{input:.025,output:.2,cached_input:.003}}})
 const {
   decode,
   decodeAsyncGenerator,

--- a/src/model/gpt-5-nano.ts
+++ b/src/model/gpt-5-nano.ts
@@ -9,7 +9,7 @@ import { GptEncoding } from '../GptEncoding.js'
 export * from '../constants.js'
 export * from '../specialTokens.js'
 // prettier-ignore
-const api = GptEncoding.getEncodingApiForModel('gpt-5-nano', () => bpeRanks, {name:"gpt-5-nano-2025-08-07",slug:"gpt-5-nano-2025-08-07",performance:2,latency:5,modalities:{input:["text","image"],output:["text"]},context_window:400000,max_output_tokens:128000,max_input_tokens:272000,knowledge_cutoff:new Date(1717113600000),supported_features:["streaming","function_calling","file_search","file_uploads","structured_outputs","image_input","prompt_caching"],supported_endpoints:["chat_completions","responses","batch"],reasoning_tokens:true})
+const api = GptEncoding.getEncodingApiForModel('gpt-5-nano', () => bpeRanks, {name:"gpt-5-nano-2025-08-07",slug:"gpt-5-nano-2025-08-07",performance:2,latency:5,modalities:{input:["text","image"],output:["text"]},context_window:400000,max_output_tokens:128000,max_input_tokens:272000,knowledge_cutoff:new Date(1717113600000),supported_features:["streaming","function_calling","file_search","file_uploads","structured_outputs","image_input","prompt_caching"],supported_endpoints:["chat_completions","responses","batch"],reasoning_tokens:true,price_data:{main:{input:.05,output:.4,cached_input:.005},batch:{input:.025,output:.2,cached_input:.003}}})
 const {
   decode,
   decodeAsyncGenerator,

--- a/src/models.gen.ts
+++ b/src/models.gen.ts
@@ -3174,6 +3174,18 @@ const gpt_5_nano_2025_08_07_spec = {
     'batch',
   ],
   reasoning_tokens: true,
+  price_data: {
+    main: {
+      input: 0.05,
+      output: 0.4,
+      cached_input: 0.005,
+    },
+    batch: {
+      input: 0.025,
+      output: 0.2,
+      cached_input: 0.003,
+    },
+  },
 } as const satisfies ModelSpec
 export {gpt_5_nano_2025_08_07_spec as 'gpt-5-nano-2025-08-07'}
 


### PR DESCRIPTION
   ## Summary
   Adds missing pricing information for `gpt-5-nano-2025-08-07` model.
   Fixes [#86]
    
   ## Changes
   - Added `price_data` to `gpt_5_nano_2025_08_07_spec` in `src/models.gen.ts`
   - Pricing includes main API and batch API costs for input, output, and cached input tokens
   - Model files (`src/model/gpt-5-nano*.ts`) regenerated with `yarn codegen:models` 
   
   ## Pricing Details
   **Main API** (per 1M tokens):
   - Input: $0.05
   - Output: $0.40
   - Cached input: $0.005
   
   **Batch API** (per 1M tokens):
   - Input: $0.025
   - Output: $0.20
   - Cached input: $0.003
   
   ## Notes
   - Pricing data sourced from OpenAI's pricing page